### PR TITLE
Update virtual environment instructions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -35,8 +35,8 @@ A Model Context Protocol (MCP) server that integrates the UI.com Site Manager AP
 
 2. **Set up virtual environment**
    ```bash
-   python3 -m venv venv
-   source venv/bin/activate  # On Windows: venv\Scripts\activate
+   python3 -m venv .venv
+   source .venv/bin/activate  # On Windows: .venv\Scripts\activate
    pip install -r requirements.txt
    ```
 
@@ -180,7 +180,7 @@ curl -X GET "http://localhost:8000/mcp/tools/get_isp_metrics" \
 Run the API coverage test:
 
 ```bash
-source venv/bin/activate
+source .venv/bin/activate
 python3 test_unifi_client.py
 ```
 


### PR DESCRIPTION
## Summary
- update virtual environment creation instructions to `.venv`
- adjust activation commands for Unix/Windows

## Testing
- `python3 -m pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6845e99c382c83228748a94295740191