### PR TITLE
Update default UNIFI_API_URL references

### DIFF
--- a/docs/3_configuration_guide.md
+++ b/docs/3_configuration_guide.md
@@ -11,7 +11,7 @@ The Unifi MCP Server uses environment variables for configuration. These can be 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `UNIFI_API_KEY` | Yes | None | Your Unifi Site Manager API key |
-| `UNIFI_API_URL` | No | `https://sitemanager.ui.com/api` | The base URL for the Unifi Site Manager API |
+| `UNIFI_API_URL` | No | `https://api.ui.com` | The base URL for the Unifi Site Manager API |
 
 ### The `.env` File
 
@@ -22,8 +22,8 @@ The `.env` file is the recommended way to configure the server. A template is pr
 # Get this from Unifi console: Settings → Control Plane → Integrations → Create API Key
 UNIFI_API_KEY=your_api_key_here
 
-# Unifi API URL (optional, defaults to https://sitemanager.ui.com/api)
-UNIFI_API_URL=https://sitemanager.ui.com/api
+# Unifi API URL (optional, defaults to https://api.ui.com)
+UNIFI_API_URL=https://api.ui.com
 ```
 
 Copy this template to create your `.env` file:

--- a/docs/6_docker_deployment.md
+++ b/docs/6_docker_deployment.md
@@ -45,7 +45,7 @@ Create a `.env` file in the project directory with your Unifi API key:
 
 ```
 UNIFI_API_KEY=your_api_key_here
-UNIFI_API_URL=https://sitemanager.ui.com/api
+UNIFI_API_URL=https://api.ui.com
 ```
 
 ### Step 2: Deploy with Docker Compose
@@ -96,7 +96,7 @@ docker run -d \
   --name unifi-mcp-server \
   -p 8000:8000 \
   -e UNIFI_API_KEY=your_api_key_here \
-  -e UNIFI_API_URL=https://sitemanager.ui.com/api \
+  -e UNIFI_API_URL=https://api.ui.com \
   -v ./logs:/app/logs \
   unifi-mcp-server
 ```
@@ -126,7 +126,7 @@ The Docker deployment supports the following environment variables:
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `UNIFI_API_KEY` | Yes | None | Your Unifi Site Manager API key |
-| `UNIFI_API_URL` | No | `https://sitemanager.ui.com/api` | The base URL for the Unifi Site Manager API |
+| `UNIFI_API_URL` | No | `https://api.ui.com` | The base URL for the Unifi Site Manager API |
 | `PYTHONUNBUFFERED` | No | 1 | Ensures Python output is sent straight to the container log |
 
 ## Volumes
@@ -170,7 +170,7 @@ services:
       - "8000:8000"
     environment:
       - UNIFI_API_KEY=${UNIFI_API_KEY}
-      - UNIFI_API_URL=${UNIFI_API_URL:-https://sitemanager.ui.com/api}
+      - UNIFI_API_URL=${UNIFI_API_URL:-https://api.ui.com}
     restart: unless-stopped
     volumes:
       - ./logs:/app/logs

--- a/docs/7_troubleshooting_guide.md
+++ b/docs/7_troubleshooting_guide.md
@@ -85,7 +85,7 @@ This guide helps you diagnose and resolve common issues with the Unifi MCP Serve
 1. Check the format of your `.env` file:
    ```
    UNIFI_API_KEY=your_api_key_here
-   UNIFI_API_URL=https://sitemanager.ui.com/api
+   UNIFI_API_URL=https://api.ui.com
    ```
 2. Ensure there are no spaces around the `=` sign.
 3. Make sure there are no quotes around the values unless they're part of the value.

--- a/docs/data_flow_architecture.md
+++ b/docs/data_flow_architecture.md
@@ -276,7 +276,7 @@ Tool Invocation: {
 }
 
 API Request:
-GET https://sitemanager.ui.com/api/sites/site1/devices
+GET https://api.ui.com/sites/site1/devices
 Headers: {
   "Authorization": "Bearer unifi_api_key",
   "Content-Type": "application/json"


### PR DESCRIPTION
## Summary
- update default UNIFI_API_URL in configuration guide
- update docker deployment docs to show new default
- update troubleshooting guide and data flow example to use https://api.ui.com

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6845f32b0c4483229fa1a60a5ea6feee